### PR TITLE
Ignore magic numbers (from TS) for all test files

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ module.exports = {
       rules: {
         // DISABLED RULES FOR TEST FILES
 
-        'no-magic-numbers': 'off',
+        '@typescript-eslint/no-magic-numbers': 'off',
         'max-lines-per-function': 'off',
         'max-lines': 'off',
         curly: 'off',


### PR DESCRIPTION
We replaced the rule for magic numbers with TS variant and did not modify preset for test to keep it ignored resulting in many magic number cases reported from test file in projects