### PR TITLE
Extend javascript config in react config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Some configs extend other configs, as illustrated below. So, for example, extend
     node --extends--> javascript
     angular --extends--> typescript
     ngrx --extends--> angular
+    react --extends--> javascript
     graphql --extends--> node
 ```
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -20,7 +20,9 @@ Config for **React** projects.
    export default tseslint.config(...react);
    ```
 
-## 📏 Rules (101)
+## 📏 Rules (391)
+
+**290** rules are included from [`javascript` config](./javascript.md#📏-rules-290). For brevity, only the **101** additional rules are listed in this document.
 
 > 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).<br>💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).<br>🧪🚫 Disabled for [test files](../README.md#🧪-test-overrides).<br>🧪⚠️ Severity lessened to warning for [test files](../README.md#🧪-test-overrides).
 

--- a/src/configs/react.js
+++ b/src/configs/react.js
@@ -6,8 +6,9 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 import { REACT_FILE_PATTERNS } from '../lib/patterns.js';
+import javascript from './javascript.js';
 
-export default tseslint.config({
+export default tseslint.config(...javascript, {
   files: REACT_FILE_PATTERNS,
   languageOptions: {
     globals: globals.browser,

--- a/tests/configs/react.spec.js
+++ b/tests/configs/react.spec.js
@@ -20,6 +20,11 @@ describe('react config', () => {
     expect(Object.keys(config.rules ?? {}).join(',')).toContain('react/');
   });
 
+  it('should have rule from extended javascript config', async () => {
+    const config = await loadConfig('components/Button.tsx');
+    expect(config.rules).toHaveProperty('@typescript-eslint/no-unused-vars');
+  });
+
   it('should have rule from extended recommended react config', async () => {
     const config = await loadConfig();
     expect(config.rules).toHaveProperty('react/jsx-key');


### PR DESCRIPTION
Follow-up to:
- #33

React config now extends base JavaScript config, so that React projects need only import `@code-pushup/eslint-config/react.js`. This is similar to Angular config, except that also extends TypeScript config - unlike Angular, TypeScript is not a prerequisite for React, however.
