### PR TITLE
MVP for supporting Vue

### DIFF
--- a/src/configs/javascript.js
+++ b/src/configs/javascript.js
@@ -17,12 +17,13 @@ import {
   SVELTE_FILE_PATTERNS,
   TEST_FILE_PATTERNS,
   TYPESCRIPT_DECLARATION_FILE_PATTERNS,
+  VUE_FILE_PATTERNS,
 } from '../lib/patterns.js';
 import { convertErrorsToWarnings } from '../lib/utils.js';
 
 export default tseslint.config(
   {
-    files: JS_TS_JSON_FILE_PATTERNS,
+    files: [...JS_TS_JSON_FILE_PATTERNS, ...VUE_FILE_PATTERNS],
     extends: [
       eslint.configs.recommended,
       ...tseslint.configs.recommended,

--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -8,6 +8,7 @@ import {
   STORYBOOK_FILE_PATTERNS,
   TEST_FILE_PATTERNS,
   TYPESCRIPT_FILE_PATTERNS,
+  VUE_FILE_PATTERNS,
 } from '../lib/patterns.js';
 import {
   IMMUTABLE_DATA_OPTIONS,
@@ -19,7 +20,7 @@ import javascript from './javascript.js';
 export default tseslint.config(
   ...javascript,
   {
-    files: TYPESCRIPT_FILE_PATTERNS,
+    files: [...TYPESCRIPT_FILE_PATTERNS, ...VUE_FILE_PATTERNS],
     extends: [
       ...tseslint.configs.recommendedTypeChecked,
       ...tseslint.configs.strictTypeChecked,

--- a/src/lib/patterns.js
+++ b/src/lib/patterns.js
@@ -68,6 +68,8 @@ export const JS_TS_JSON_FILE_PATTERNS = [
 
 export const REACT_FILE_PATTERNS = withExtensions(['**/*']);
 
+export const VUE_FILE_PATTERNS = ['**/*.vue'];
+
 export const HTML_FILE_PATTERNS = ['**/*.html'];
 
 export const CYPRESS_FILE_PATTERNS = [


### PR DESCRIPTION
In Vue, a [single file component](https://vuejs.org/guide/scaling-up/sfc) may contain a `<template>`, `<script>` and `<style>`. The [`vue-eslint-parser`](https://www.npmjs.com/package/vue-eslint-parser) does not create temporary JS/TS files for the `<script>` part of the file, it merely updates the AST. As such, in order to apply JS/TS rules to the `<script>` part of the `.vue` file, the file extension needs to be supported within the file pattern of the configuration.

Ideally, the preset would allow extending the file patterns. For now, including the `.vue` format within both `javascript` and `typescript` config helps support Vue project while not affecting functionality on projects using other frameworks.

