### PR TITLE
Turn on type checked rules for .vue files

### DIFF
--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -154,7 +154,7 @@ export default tseslint.config(
     },
   },
   {
-    files: negatePatterns(TYPESCRIPT_FILE_PATTERNS),
+    files: negatePatterns([...TYPESCRIPT_FILE_PATTERNS, ...VUE_FILE_PATTERNS]),
     ...tseslint.configs.disableTypeChecked,
   },
 );


### PR DESCRIPTION
After previous PR #40 with the Vue setup, type checked rules stayed disabled for `.vue` files. This PR fixes that.