### PR TITLE
fix(create-eslint-config): add license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # @code-pushup/eslint-config
 
-[![npm](https://img.shields.io/npm/v/%40code-pushup%2Feslint-config.svg)](https://www.npmjs.com/package/@code-pushup/eslint-config)
+[![version](https://img.shields.io/github/v/release/code-pushup/eslint-config)](https://github.com/code-pushup/eslint-config/releases/latest)
+[![release date](https://img.shields.io/github/release-date/code-pushup/eslint-config)](https://github.com/code-pushup/eslint-config/releases)
+[![commit activity](https://img.shields.io/github/commit-activity/m/code-pushup/eslint-config)](https://github.com/code-pushup/eslint-config/pulse/monthly)
+[![license](https://img.shields.io/github/license/code-pushup/eslint-config)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/code-pushup/eslint-config/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/code-pushup/eslint-config/actions/workflows/ci.yml?query=branch%3Amain)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Monorepo for [Code PushUp](https://github.com/code-pushup/cli) ESLint packages.
 
 ## Packages
 
-| Package                                                              | Description                                  |
-| :------------------------------------------------------------------- | :------------------------------------------- |
-| [`@code-pushup/eslint-config`](./packages/eslint-config/README.md)  | Recommended ESLint presets by Code PushUp     |
+| Package                                                                          | Description                                               |
+| :------------------------------------------------------------------------------- | :-------------------------------------------------------- |
+| [`@code-pushup/eslint-config`](./packages/eslint-config/README.md)               | Recommended ESLint presets by Code PushUp                 |
 | [`@code-pushup/create-eslint-config`](./packages/create-eslint-config/README.md) | Interactive setup wizard for `@code-pushup/eslint-config` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@code-pushup/eslint-config-workspace",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "prepare": "husky install",

--- a/packages/create-eslint-config/LICENSE
+++ b/packages/create-eslint-config/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Code PushUp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/create-eslint-config/README.md
+++ b/packages/create-eslint-config/README.md
@@ -1,7 +1,9 @@
 # @code-pushup/create-eslint-config
 
 [![npm](https://img.shields.io/npm/v/%40code-pushup%2Fcreate-eslint-config.svg)](https://www.npmjs.com/package/@code-pushup/create-eslint-config)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![downloads](https://img.shields.io/npm/dm/%40code-pushup%2Fcreate-eslint-config)](https://npmtrends.com/@code-pushup/create-eslint-config)
+[![dependencies](https://img.shields.io/librariesio/release/npm/%40code-pushup/create-eslint-config)](https://www.npmjs.com/package/@code-pushup/create-eslint-config?activeTab=dependencies)
+[![license](https://img.shields.io/npm/l/%40code-pushup%2Fcreate-eslint-config)](https://opensource.org/licenses/MIT)
 
 Interactive setup wizard for [`@code-pushup/eslint-config`](../eslint-config/README.md).
 
@@ -31,14 +33,14 @@ npm init @code-pushup/eslint-config -- --yes
 
 ### Options
 
-| Option                      | Type                                             | Default       | Description                        |
-| --------------------------- | ------------------------------------------------ | ------------- | ---------------------------------- |
-| **`--configs`**             | `string[]`                                       |               | Configs to include                 |
-| **`--tsconfig`**            | `string`                                         | auto-detected | Path to tsconfig                   |
-| **`--node-version-source`** | `'node-version'` \| `'engines'` \| `'manual'`   | auto-detected | Where to read the Node version     |
-| **`--node-version`**        | `string`                                         |               | Node version range (e.g. `>=20.0.0`) |
-| **`--dry-run`**             | `boolean`                                        | `false`       | Preview changes without writing    |
-| **`--yes`**, `-y`           | `boolean`                                        | `false`       | Skip prompts and use defaults      |
+| Option                      | Type                                          | Default       | Description                          |
+| --------------------------- | --------------------------------------------- | ------------- | ------------------------------------ |
+| **`--configs`**             | `string[]`                                    |               | Configs to include                   |
+| **`--tsconfig`**            | `string`                                      | auto-detected | Path to tsconfig                     |
+| **`--node-version-source`** | `'node-version'` \| `'engines'` \| `'manual'` | auto-detected | Where to read the Node version       |
+| **`--node-version`**        | `string`                                      |               | Node version range (e.g. `>=20.0.0`) |
+| **`--dry-run`**             | `boolean`                                     | `false`       | Preview changes without writing      |
+| **`--yes`**, `-y`           | `boolean`                                     | `false`       | Skip prompts and use defaults        |
 
 ### Programmatic API
 
@@ -56,20 +58,20 @@ const result = await runSetupWizard({
 
 ## Available configs
 
-| Slug                     | Detected when                                      |
-| ------------------------ | -------------------------------------------------- |
-| `javascript`             | Always recommended                                 |
-| `typescript`             | `tsconfig.json` exists or `typescript` is installed |
-| `node`                   | Backend/full-stack framework is installed           |
-| `angular`                | `@angular/core` is installed                       |
-| `ngrx`                   | `@ngrx/core` is installed                          |
-| `react`                  | `react` is installed                               |
-| `graphql`                | GraphQL server package is installed                |
-| `jest`                   | `jest` is installed or config file exists           |
-| `vitest`                 | `vitest` is installed or config file exists         |
-| `cypress`                | `cypress` is installed or config file exists        |
-| `playwright`             | `@playwright/test` is installed or config exists   |
-| `storybook`              | `storybook` is installed or `.storybook` exists    |
-| `react-testing-library`  | `@testing-library/react` is installed              |
+| Slug                    | Detected when                                       |
+| ----------------------- | --------------------------------------------------- |
+| `javascript`            | Always recommended                                  |
+| `typescript`            | `tsconfig.json` exists or `typescript` is installed |
+| `node`                  | Backend/full-stack framework is installed           |
+| `angular`               | `@angular/core` is installed                        |
+| `ngrx`                  | `@ngrx/core` is installed                           |
+| `react`                 | `react` is installed                                |
+| `graphql`               | GraphQL server package is installed                 |
+| `jest`                  | `jest` is installed or config file exists           |
+| `vitest`                | `vitest` is installed or config file exists         |
+| `cypress`               | `cypress` is installed or config file exists        |
+| `playwright`            | `@playwright/test` is installed or config exists    |
+| `storybook`             | `storybook` is installed or `.storybook` exists     |
+| `react-testing-library` | `@testing-library/react` is installed               |
 
 Configs follow an inheritance hierarchy. Selecting a child preset subsumes its parent. For example, picking `typescript` automatically includes `javascript`.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,7 +1,9 @@
 # @code-pushup/eslint-config
 
 [![npm](https://img.shields.io/npm/v/%40code-pushup%2Feslint-config.svg)](https://www.npmjs.com/package/@code-pushup/eslint-config)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![downloads](https://img.shields.io/npm/dm/%40code-pushup%2Feslint-config)](https://npmtrends.com/@code-pushup/eslint-config)
+[![dependencies](https://img.shields.io/librariesio/release/npm/%40code-pushup/eslint-config)](https://www.npmjs.com/package/@code-pushup/eslint-config?activeTab=dependencies)
+[![license](https://img.shields.io/npm/l/%40code-pushup%2Feslint-config)](https://opensource.org/licenses/MIT)
 
 Recommended ESLint presets by [Code PushUp](https://github.com/code-pushup/cli/tree/main/packages/cli).
 


### PR DESCRIPTION
The main purpose of this PR is to trigger a minor release and test the automated npm publish workflow (see #53, #48). The release workflow has already been tested for the "nothing to publish" case and [passed](https://github.com/code-pushup/eslint-config/actions/runs/25800528208/job/75789008122).

The "fix" is to add a missing `LICENSE` file. While at it, I brought the badges and metadata in line with the `code-pushup/cli` repo.